### PR TITLE
using replace from cpp stl library to remove boost dependency

### DIFF
--- a/filter.cpp
+++ b/filter.cpp
@@ -28,10 +28,19 @@ std::string replace_multiple_spaces(std::string query)
     }
 }
 
+void replace_all_substrings(std::string& source_string, const std::string source_pattern, const std::string target_pattern) {
+    if (source_pattern.size() == 0) return;
+    size_t pos = 0;
+    while ((pos = source_string.find(source_pattern, pos)) != std::string::npos) {
+        source_string.replace(pos, source_pattern.length(), target_pattern);
+        pos += target_pattern.length();
+    }
+}
+
 std::string replace_space_before_parenthesis(std::string query)
 {
-    boost::replace_all(query, "( ", "(");
-    boost::replace_all(query, " )", ")");
+    replace_all_substrings(query, "( ", "(");
+    replace_all_substrings(query, " )", ")");
     
     return query;
 }

--- a/filter.h
+++ b/filter.h
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <unordered_map>
 #include <algorithm>
-#include <boost/algorithm/string/replace.hpp>
 #include "datastructure.h"
 
 struct FilterTree {
@@ -14,7 +13,9 @@ struct FilterTree {
     FilterTree *right;
 };
 
+void replace_all_substrings(std::string& source_string, const std::string source_pattern, const std::string target_pattern);
 std::string replace_multiple_spaces(std::string query);
 std::string replace_space_before_parenthesis(std::string query);
 bool filter(const FilterTree *tree, const str_str_umap row, const str_str_umap dtypes);
 FilterTree* build_filter_tree(std::string query);
+


### PR DESCRIPTION
Using boost just for replacing substring seems to be an overkill.
Removing boost dependency and using stl's replace function.